### PR TITLE
Implement `defmt::Format`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ sync = ["dep:embedded-hal"]
 # Provide an async driver implementation
 async = ["dep:embedded-hal-async"]
 
+# Provide defmt 'Format'.
+defmt = ["dep:defmt"]
+
 
 # Use the standard library and impl std::error::Error on all error types
 std = []
@@ -56,6 +59,7 @@ required-features = ["sync", "std", "no_transaction"]
 [dependencies]
 embedded-hal = { version = "1.0.0", optional = true }
 embedded-hal-async = { version = "1.0.0", optional = true }
+defmt = { version = "1", optional = true }
 
 [dev-dependencies]
 linux-embedded-hal = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This crate has the following feature flags (default features in bold):
 | **async**      | Provide an async driver implementation                                 |
 | **paranoid**   | Perform extra checks                                                   |
 | no_transaction | Disable use of transactions and perform individual system calls        |
+| defmt          | Use defmt::Format instead of Display for headless/no_std systems       |
 | std            | Use the standard library and impl std::error::Error on all error types |
 
 For more detailed descriptions see [Cargo.toml](Cargo.toml).

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -243,6 +243,13 @@ impl Display for MicroAmpere {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for MicroAmpere {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{} µA", self.0);
+    }
+}
+
 /// A power measurement in µW
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct MicroWatt(pub i64);
@@ -250,6 +257,13 @@ pub struct MicroWatt(pub i64);
 impl Display for MicroWatt {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} µW", self.0)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for MicroWatt {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{} µW", self.0);
     }
 }
 

--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -110,6 +110,13 @@ impl Display for ShuntVoltage {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for ShuntVoltage {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{} µV", self.shunt_voltage_uv());
+    }
+}
+
 impl Debug for ShuntVoltage {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ShuntVoltage")
@@ -206,6 +213,13 @@ impl BusVoltage {
 impl Display for BusVoltage {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} mV", self.voltage_mv())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for BusVoltage {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{} mV", self.voltage_mv());
     }
 }
 


### PR DESCRIPTION
[Reference to ticket #4]

How's this? Seems to work fine:
```
0.000495 INFO  Start
0.006682 INFO  Voltage (Bus):   4208 mV
0.007263 INFO  Voltage (Shunt): -30 µV
```

Using the code:
```
        info!("Voltage (Bus):   {}", ina.bus_voltage().unwrap());
        info!("Voltage (Shunt): {}", ina.shunt_voltage().unwrap());
```

Do you want me to include an example using Embassy and defmt?